### PR TITLE
Only run DOM operations in the client when there is a document (#17570)

### DIFF
--- a/packages/vite/src/client/client.ts
+++ b/packages/vite/src/client/client.ts
@@ -208,6 +208,10 @@ async function handleMessage(payload: HotPayload) {
             return hmrClient.queueUpdate(update)
           }
 
+          if (!hasDocument) {
+            return
+          }
+
           // css-update
           // this is only sent when a css file referenced with <link> is updated
           const { path, timestamp } = update
@@ -314,16 +318,20 @@ const enableOverlay = __HMR_ENABLE_OVERLAY__
 const hasDocument = 'document' in globalThis
 
 function createErrorOverlay(err: ErrorPayload['err']) {
-  clearErrorOverlay()
-  document.body.appendChild(new ErrorOverlay(err))
+  if (hasDocument) {
+    clearErrorOverlay()
+    document.body.appendChild(new ErrorOverlay(err))
+  }
 }
 
 function clearErrorOverlay() {
-  document.querySelectorAll<ErrorOverlay>(overlayId).forEach((n) => n.close())
+  if (hasDocument) {
+    document.querySelectorAll<ErrorOverlay>(overlayId).forEach((n) => n.close())
+  }
 }
 
 function hasErrorOverlay() {
-  return document.querySelectorAll(overlayId).length
+  return hasDocument ? document.querySelectorAll(overlayId).length : 0
 }
 
 async function waitForSuccessfulPing(
@@ -357,7 +365,7 @@ async function waitForSuccessfulPing(
   await wait(ms)
 
   while (true) {
-    if (document.visibilityState === 'visible') {
+    if (hasDocument && document.visibilityState === 'visible') {
       if (await ping()) {
         break
       }
@@ -374,6 +382,9 @@ function wait(ms: number) {
 
 function waitForWindowShow() {
   return new Promise<void>((resolve) => {
+    if (!hasDocument) {
+      return
+    }
     const onChange = async () => {
       if (document.visibilityState === 'visible') {
         resolve()
@@ -388,7 +399,7 @@ const sheetsMap = new Map<string, HTMLStyleElement>()
 
 // collect existing style elements that may have been inserted during SSR
 // to avoid FOUC or duplicate styles
-if ('document' in globalThis) {
+if (hasDocument) {
   document
     .querySelectorAll<HTMLStyleElement>('style[data-vite-dev-id]')
     .forEach((el) => {
@@ -397,7 +408,7 @@ if ('document' in globalThis) {
 }
 
 const cspNonce =
-  'document' in globalThis
+  hasDocument
     ? document.querySelector<HTMLMetaElement>('meta[property=csp-nonce]')?.nonce
     : undefined
 
@@ -406,6 +417,10 @@ const cspNonce =
 let lastInsertedStyle: HTMLStyleElement | undefined
 
 export function updateStyle(id: string, content: string): void {
+  if (!hasDocument) {
+    return
+  }
+  
   let style = sheetsMap.get(id)
   if (!style) {
     style = document.createElement('style')
@@ -435,6 +450,9 @@ export function updateStyle(id: string, content: string): void {
 }
 
 export function removeStyle(id: string): void {
+  if (!hasDocument) {
+    return
+  }
   const style = sheetsMap.get(id)
   if (style) {
     document.head.removeChild(style)


### PR DESCRIPTION
### Description

When the client runs in a worker there are no DOM operations available and will throw errors. There were already some checks in place, but this PR adds checks in all the places.

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Read the Contributing Guidelines at https://github.com/vitejs/vite/blob/main/CONTRIBUTING.md.
- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Vite!
----------------------------------------------------------------------->
